### PR TITLE
check-device-response周りのバグ修正

### DIFF
--- a/src/task_cabinet_server/handler/user_device.clj
+++ b/src/task_cabinet_server/handler/user_device.clj
@@ -8,13 +8,14 @@
 (s/def ::auth string?)
 (s/def ::p256dh string?)
 (s/def ::password string?)
+(s/def ::is_exist int?)
 (s/def ::path-params (s/keys :req-un [::user-id]))
 (s/def ::keys (s/keys :req-un [::auth ::p256dh]))
 (s/def ::add-device-params (s/keys :req-un [::endpoint ::keys]))
 (s/def ::add-device-response (s/keys :req-un [::endpoint ::keys]))
 (s/def ::remove-device-params (s/keys :req-un [::endpoint ::keys]))
 (s/def ::remove-all-device-params (s/keys :req-un [::password]))
-(s/def ::check-device-response (s/keys :req-un [:is_exist]))
+(s/def ::check-device-response (s/keys :req-un [::is_exist]))
 
 (def add-device
   {:summary "add a device receives webpush"

--- a/src/task_cabinet_server/service/user_device.clj
+++ b/src/task_cabinet_server/service/user_device.clj
@@ -69,8 +69,8 @@
         (if-not (-> (udsql/check-device-exists? db
                                                 {:user_id user-id :endpoint endpoint :auth auth :p256dh p256dh})
                     count zero?)
-          {:status 200 :body {:is_exist 1}}
-          {:status 200 :body {:is_exist 0}})))))
+          {:status 200 :body {:result {:is_exist 1}}}
+          {:status 200 :body {:result {:is_exist 0}}})))))
 
 (defn add-device-handler
   "add devices


### PR DESCRIPTION
サーバー立ち上がらなかったので、少しいじりました。

素人なので、いい感じに修正してもらえると助かります

## バグ1 サーバーが立ち上がらない
**エラーコード**
```
Unexpected error (AssertionError) macroexpanding s/keys at (user_device.clj:17:32).
Assert failed: all keys must be namespace-qualified keywords
(every? (fn* [p1__1917#] (c/and (keyword? p1__1917#) (namespace p1__1917#))) (concat req-keys req-un-specs opt opt-un))
```

**修正箇所**
https://github.com/MokkeMeguru/tcs-service/pull/11/files#diff-2b1f000b29292b117d47de355ddd9f1e

## バグ2 500エラーが返ってくる
**レスポンス**
```
{
  "spec": "(spec-tools.core/spec {:spec (clojure.spec.alpha/keys :req-un [:spec$27936/result]), :type :map, :leaf? false})",
  "problems": [
    {
      "path": [],
      "pred": "(clojure.core/fn [%] (clojure.core/contains? % :result))",
      "val": {
        "is_exist": 1
      },
      "via": [],
      "in": []
    }
  ],
  "type": "reitit.coercion/response-coercion",
  "coercion": "spec",
  "value": {
    "is_exist": 1
  },
  "in": [
    "response",
    "body"
  ]
}
```

**修正箇所**
https://github.com/MokkeMeguru/tcs-service/pull/11/files#diff-6328cbd15cda5bdd2e0e380acd626173